### PR TITLE
switch to checking `WAYLAND_DISPLAY` from `XDG_SESSION_TYPE`

### DIFF
--- a/src/pcmanfm.c
+++ b/src/pcmanfm.c
@@ -206,7 +206,7 @@ int main(int argc, char** argv)
     textdomain ( GETTEXT_PACKAGE );
 #endif
 
-    if (!strcmp (getenv ("XDG_SESSION_TYPE"), "wayland")) use_wayland = TRUE;
+    if (getenv ("WAYLAND_DISPLAY")) use_wayland = TRUE;
 
     /* initialize GTK+ and parse the command line arguments */
     if(G_UNLIKELY(!gtk_init_with_args(&argc, &argv, " ", opt_entries, GETTEXT_PACKAGE, &err)))


### PR DESCRIPTION
running with sudo previously caused a segfault. this was due to `XDG_SESSION_TYPE` being unset when run in the XWAYLAND process and attempting to do a string comparison on the null input. Now use `WAYLAND_DISPLAY` environment variable presence to more accurately test for wayland vs xwayland/x11 usage

fixes: https://github.com/raspberrypi/bookworm-feedback/issues/85
fixes: https://forums.raspberrypi.com/viewtopic.php?t=357664

edit: force push for better commit message